### PR TITLE
Update to Elixir 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ $ touch .eslintrc
 ```
 
 ```javascript
+// gulpfile.js
 var elixir = require('laravel-elixir');
 
 require('laravel-elixir-eslint');
@@ -20,8 +21,10 @@ elixir(function(mix) {
 ## Options
 
 ### Sources
-Glob or array of globs to read. Using this will overwrite all defaults.
 Type: `String` or `Array`
+
+Glob or array of globs to read. Using this will overwrite all defaults.
+
 Default:
 
 ```javascript
@@ -34,8 +37,11 @@ mix.eslint([
 _The prefix `!` is for excluding files._
 
 ### ESLint options
+
 Type: `Object`
+
 Options for ESLint.
+
 _See [eslint.org/docs/user-guide/configuring](http://eslint.org/docs/user-guide/configuring)_
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ $ npm install laravel-elixir-eslint --save-dev
 $ touch .eslintrc
 ```
 
-## Usage
-
-### Example Gulpfile
-
 ```javascript
 var elixir = require('laravel-elixir');
 
@@ -21,7 +17,12 @@ elixir(function(mix) {
 });
 ```
 
-### Advanced example
+## Options
+
+### Sources
+Glob or array of globs to read. Using this will overwrite all defaults.
+Type: `String` or `Array`
+Default:
 
 ```javascript
 mix.eslint([
@@ -29,3 +30,15 @@ mix.eslint([
   '!public/js/vendor/**/*.js'
 ]);
 ```
+
+_The prefix `!` is for excluding files._
+
+### ESLint options
+Type: `Object`
+Options for ESLint.
+_See [eslint.org/docs/user-guide/configuring](http://eslint.org/docs/user-guide/configuring)_
+
+## Credits
+- [gulp-eslint](https://github.com/adametry/gulp-eslint)
+- [laravel-elixir](https://github.com/laravel/elixir)
+- [All contributors](https://github.com/ponko2/laravel-elixir-eslint/graphs/contributors) to this project.

--- a/index.js
+++ b/index.js
@@ -1,45 +1,25 @@
 'use strict';
 
-var gulp   = require('gulp');
+var gulp = require('gulp');
 var eslint = require('gulp-eslint');
-var notify = require('gulp-notify');
-var elixir = require('laravel-elixir');
-var path   = require('path');
 
-elixir.extend('eslint', function(src, options) {
-  src = src || [
-    'public/js/**/*.js',
-    '!public/js/vendor/**/*.js'
-  ];
+var Elixir = require('laravel-elixir');
+var config = Elixir.config;
 
-  options = options || {};
+Elixir.extend('eslint', function(src, options) {
+    var paths = new Elixir.GulpPaths()
+        .src(src || [
+            config.get('public.js.outputFolder') + '/**/*.js',
+            '!' + config.get('public.js.outputFolder') + '/vendor/**/*.js'
+        ]);
 
-  var onError = function(err) {
-    notify.onError({
-      title: 'Laravel Elixir',
-      subtitle: 'ESLint failed.',
-      message: '<%= error.message %>',
-      icon: path.join(__dirname, '../laravel-elixir/icons/fail.png')
-    })(err);
+    new Elixir.Task('eslint', function() {
+        this.log(paths.src);
 
-    this.emit('end');
-  };
+        return gulp.src(paths.src.path)
+            .pipe(eslint(options || {}))
+            .pipe(eslint.format())
+            .pipe(eslint.failAfterError());
 
-  gulp.task('eslint', function() {
-    return gulp.src(src)
-      .pipe(eslint(options))
-      .pipe(eslint.format())
-      .pipe(eslint.failAfterError())
-      .on('error', onError)
-      .pipe(notify({
-        title: 'Laravel Elixir',
-        message: 'ESLint passed',
-        icon: path.join(__dirname, '../laravel-elixir/icons/pass.png'),
-        onLast: true
-      }));
-  });
-
-  this.registerWatcher('eslint', src);
-
-  return this.queueTask('eslint');
+    }).watch(paths.src);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-elixir-eslint",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Laravel Elixir ESLint Extension",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,8 @@
   },
   "homepage": "https://github.com/ponko2/laravel-elixir-eslint",
   "dependencies": {
-    "gulp-eslint": "^0.11.1",
-    "gulp-notify": "^2.0.0"
+    "gulp": "^3.9.0",
+    "gulp-eslint": "^1.0.0",
+    "laravel-elixir": "^3.0.0"
   }
 }


### PR DESCRIPTION
こんいちわ

When I use your extension, I get some errors. I discovered that your code is not optimized for Laravel's Elixir version 3.0. In this pull-request I have completely rewritten your extension to support Elixir 3.0.

Furthermore, I updated the README with some more info, updated the dependencies (was required because of ESLint) in packages.json, and bumped the version to 1.0.0. In your other extensions such as [laravel-elixir-browser-sync](https://github.com/ponko2/laravel-elixir-browser-sync) I see that you are using 1.0.0. I assume that your other extensions need to be upgraded to Elixir 3.0 as well.

After upgrading I assume that the extension will not work anymore in older versions (2.0), but I didn't test that. Perhaps you need to move this existing code to a new branch before applying this pull-request, if you want to support both versions.

Thanks
